### PR TITLE
chore: update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@code-forge/remix-dev-tools",
-  "version": "1.0.0",
+  "name": "remix-development-tools",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@code-forge/remix-dev-tools",
-      "version": "1.0.0",
+      "name": "remix-development-tools",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.1.2",


### PR DESCRIPTION
I noticed that `package-lock.json` had changed after running `npm install`. This PR just commits those changes.