### PR TITLE
Support custom routing

### DIFF
--- a/src/RemixDevTools/tabs/PageTab.tsx
+++ b/src/RemixDevTools/tabs/PageTab.tsx
@@ -6,6 +6,7 @@ import { useGetSocket } from "../hooks/useGetSocket";
 import { Tag } from "../components/Tag";
 import { VsCodeButton } from "../components/VScodeButton";
 import { useMemo } from "react";
+import { isLayoutRoute } from "../utils/misc";
 
 export const ROUTE_COLORS: Record<string, string> = {
   ROUTE: "rdt-bg-green-500 rdt-text-white",
@@ -67,12 +68,9 @@ const PageTab = () => {
           const originalData = getOriginalData(route.data);
 
           const isRoot = route.id === "root";
-          const lastPart = route.id.split("/").pop();
-          const isLayout =
-            lastPart?.split(".")?.length === 1 &&
-            (lastPart?.startsWith("_") || lastPart?.startsWith("__")) &&
-            lastPart !== "_index" &&
-            "index";
+
+          const entryRoute = __remixManifest.routes[route.id];
+          const isLayout = isLayoutRoute(entryRoute);
 
           return (
             <li key={route.id} className="rdt-mb-8 rdt-ml-8">

--- a/src/RemixDevTools/tabs/RoutesTab.tsx
+++ b/src/RemixDevTools/tabs/RoutesTab.tsx
@@ -13,16 +13,7 @@ import { useRDTContext } from "../context/useRDTContext";
 import { Input } from "../components/Input";
 import { NewRouteForm } from "../components/NewRouteForm";
 import { useGetSocket } from "../hooks/useGetSocket";
-
-const isLayout = (route: EntryRoute & { route: string }) => {
-  const rId = route.id.replace("routes/", "");
-  const v2Layout =
-    rId.startsWith("_") &&
-    !rId.split(".")[0].endsWith("index") &&
-    rId.split(".").length === 1;
-  const v1Layout = rId.startsWith("__");
-  return v1Layout || v2Layout;
-};
+import { isLeafRoute } from "../utils/misc";
 
 const RoutesTab = () => {
   const { routeWildcards, setRouteWildcards } = useRDTContext();
@@ -35,7 +26,7 @@ const RoutesTab = () => {
           route: convertRemixPathToUrl(window.__remixManifest.routes, route),
         };
       })
-      .filter((route) => !isLayout(route) && route.id !== "root")
+      .filter((route) => isLeafRoute(route))
   );
   const navigate = useNavigate();
 

--- a/src/RemixDevTools/utils/misc.ts
+++ b/src/RemixDevTools/utils/misc.ts
@@ -1,0 +1,34 @@
+import { EntryRoute } from "@remix-run/react/dist/routes";
+
+type RouteType = "ROOT" | "LAYOUT" | "ROUTE";
+
+export function getRouteType(route: EntryRoute) {
+  let routeType: RouteType = "ROUTE";
+
+  if (route.id === "root") {
+    routeType = "ROOT";
+  } else if (route.index) {
+    routeType = "ROUTE";
+  } else if (!route.path) {
+    // Pathless layout route
+    routeType = "LAYOUT";
+  } else {
+    // Find an other route with parentId set to this route
+    const childRoute = Object.values(window.__remixManifest.routes).find(
+      (r) => r.parentId === route.id
+    );
+
+    // If this is an index route, current route is only layout route
+    routeType = childRoute?.index ? "LAYOUT" : "ROUTE";
+  }
+
+  return routeType;
+}
+
+export function isLayoutRoute(route: EntryRoute) {
+  return getRouteType(route) === "LAYOUT";
+}
+
+export function isLeafRoute(route: EntryRoute) {
+  return getRouteType(route) === "ROUTE";
+}

--- a/src/RemixDevTools/utils/misc.ts
+++ b/src/RemixDevTools/utils/misc.ts
@@ -13,13 +13,12 @@ export function getRouteType(route: EntryRoute) {
     // Pathless layout route
     routeType = "LAYOUT";
   } else {
-    // Find an other route with parentId set to this route
-    const childRoute = Object.values(window.__remixManifest.routes).find(
-      (r) => r.parentId === route.id
+    // Find an index route with parentId set to this route
+    const childIndexRoute = Object.values(window.__remixManifest.routes).find(
+      (r) => r.parentId === route.id && r.index
     );
 
-    // If this is an index route, current route is only layout route
-    routeType = childRoute?.index ? "LAYOUT" : "ROUTE";
+    routeType = childIndexRoute ? "LAYOUT" : "ROUTE";
   }
 
   return routeType;

--- a/src/remix-app-for-testing/app/routes/other._index.tsx
+++ b/src/remix-app-for-testing/app/routes/other._index.tsx
@@ -1,0 +1,3 @@
+export default function OtherIndexRoute() {
+    return <div>Other Home</div>
+}

--- a/src/remix-app-for-testing/app/routes/other.page.tsx
+++ b/src/remix-app-for-testing/app/routes/other.page.tsx
@@ -1,0 +1,3 @@
+export default function OtherPageRoute() {
+    return <div>Other Page</div>
+}

--- a/src/remix-app-for-testing/app/routes/other.tsx
+++ b/src/remix-app-for-testing/app/routes/other.tsx
@@ -1,0 +1,8 @@
+import { Outlet } from "@remix-run/react";
+
+export default function OtherLayout() {
+    return <div>
+        <h2>Other Layout</h2>
+        <Outlet />
+    </div>
+}


### PR DESCRIPTION
# Description

Detecting whether a route is a pure layout route breaks in some cases, if the code only relies on the naming conventions. Probably it is more safe to inspect the `EntryRoute` properties and inspect parent routes of index routes as well.

Fixes #17

Extract the logic to determine the route type in an extra file (as it is used twice - in active page tab and in the routes tab).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Mainly just by using the `remix-app-for-testing` and verifying that everything still works as intended after adding more routes, that broke the original implementation.

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
