### PR TITLE
Persist open state across full reloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-development-tools",
-  "version": "1.1.3",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-development-tools",
-      "version": "1.1.3",
+      "version": "1.2.2",
       "license": "MIT",
       "workspaces": [
         ".",

--- a/src/RemixDevTools/RemixDevTools.tsx
+++ b/src/RemixDevTools/RemixDevTools.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { Logo } from "./components/Logo";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { RDTContextProvider } from "./context/RDTContext";
 import { tabs } from "./tabs";
 import { useTimelineHandler } from "./hooks/useTimelineHandler";
@@ -18,9 +18,14 @@ interface Props extends RemixDevToolsProps {
 }
 
 const RemixDevTools = ({ defaultOpen, position }: Props) => {
-  const [isOpen, setIsOpen] = useState(defaultOpen);
-  const { activeTab, setActiveTab, setShouldConnectWithForge, height } =
-    useRDTContext();
+  const {
+    activeTab,
+    setActiveTab,
+    setShouldConnectWithForge,
+    height,
+    setPersistOpen,
+    persistOpen,
+  } = useRDTContext();
   const { enableResize, disableResize, isResizing } = useResize();
   useTimelineHandler();
   const { isConnected, isConnecting } = useGetSocket();
@@ -29,12 +34,15 @@ const RemixDevTools = ({ defaultOpen, position }: Props) => {
     position === "top-left" ||
     position === "bottom-left" ||
     position === "middle-left";
-
+  const isOpen = useMemo(
+    () => defaultOpen || persistOpen,
+    [persistOpen, defaultOpen]
+  );
   return (
     <div className="remix-dev-tools">
       <div
         style={{ zIndex: 9999 }}
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => setPersistOpen(!isOpen)}
         className={clsx(
           "rdt-fixed rdt-m-1.5 rdt-h-14 rdt-w-14 rdt-cursor-pointer rdt-rounded-full ",
           position === "bottom-right" && "rdt-bottom-0 rdt-right-0",

--- a/src/RemixDevTools/context/rdtReducer.ts
+++ b/src/RemixDevTools/context/rdtReducer.ts
@@ -15,6 +15,7 @@ export type RemixDevToolsState = {
     port: number;
     height: number;
   };
+  persistOpen: boolean;
 };
 
 export const initialState: RemixDevToolsState = {
@@ -28,6 +29,7 @@ export const initialState: RemixDevToolsState = {
     port: 3003,
     height: 400,
   },
+  persistOpen: false,
 };
 
 export type ReducerActions = Pick<RemixDevToolsActions, "type">["type"];
@@ -109,6 +111,11 @@ type SetShouldConnectToForgeAction = {
   payload: boolean;
 };
 
+type SetPersistOpenAction = {
+  type: "SET_PERSIST_OPEN";
+  payload: boolean;
+};
+
 /** Aggregate of all action types */
 export type RemixDevToolsActions =
   | SetTimelineEvent
@@ -123,7 +130,8 @@ export type RemixDevToolsActions =
   | SetRouteWildcards
   | SetDevToolsHeight
   | SetShouldConnectToForgeAction
-  | SetIsSubmittedAction;
+  | SetIsSubmittedAction
+  | SetPersistOpenAction;
 
 export const rdtReducer = (
   state: RemixDevToolsState = initialState,
@@ -268,6 +276,11 @@ export const rdtReducer = (
           ...state.settings,
           shouldConnectWithForge: payload,
         },
+      };
+    case "SET_PERSIST_OPEN":
+      return {
+        ...state,
+        persistOpen: payload,
       };
     default:
       return state;

--- a/src/RemixDevTools/context/useRDTContext.ts
+++ b/src/RemixDevTools/context/useRDTContext.ts
@@ -11,7 +11,8 @@ const useRDTContext = () => {
     throw new Error("useRDTContext must be used within a RDTContextProvider");
   }
   const { state, dispatch } = context;
-  const { timeline, settings, showRouteBoundaries, terminals } = state;
+  const { timeline, settings, showRouteBoundaries, terminals, persistOpen } =
+    state;
   const { activeTab, shouldConnectWithForge, routeWildcards, port, height } =
     settings;
 
@@ -118,6 +119,16 @@ const useRDTContext = () => {
     [dispatch]
   );
 
+  const setPersistOpen = useCallback(
+    (persistOpen: boolean) => {
+      dispatch({
+        type: "SET_PERSIST_OPEN",
+        payload: persistOpen,
+      });
+    },
+    [dispatch]
+  );
+
   return {
     setTimelineEvent,
     setActiveTab,
@@ -139,6 +150,8 @@ const useRDTContext = () => {
     clearTerminalOutput,
     addTerminalHistory,
     setProcessId,
+    persistOpen,
+    setPersistOpen,
   };
 };
 


### PR DESCRIPTION
# Description

Same as #16 
Not much of a GitHub experience I have :)
Anyway, I was thinking about this feature when I was modifying the URLSearchParams.
Here's a quick demo:

https://github.com/Code-Forge-Net/Remix-Dev-Tools/assets/74133458/7c328041-eecf-40f2-b9ae-d8fba6420bc4

#### Note: I used `CTRL+R` shortcut for full reloads.


Fixes # (issue)
The open state is stored in the session storage along with the other states.
If `defaultOpen` prop is set to true, It will be respected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
