### PR TITLE
fix text wrapping in Open in Browser button

### DIFF
--- a/src/RemixDevTools/tabs/RoutesTab.tsx
+++ b/src/RemixDevTools/tabs/RoutesTab.tsx
@@ -68,7 +68,7 @@ const RoutesTab = () => {
                 </span>
                 <div
                   title={pathToOpen}
-                  className="rdt-mr-2 rdt-rounded rdt-border rdt-border-gray-400 rdt-px-2 rdt-py-1 rdt-text-sm"
+                  className="rdt-mr-2 rdt-whitespace-nowrap rdt-rounded rdt-border rdt-border-gray-400 rdt-px-2 rdt-py-1 rdt-text-sm"
                   onClick={(e) => {
                     e.preventDefault();
                     navigate(path);


### PR DESCRIPTION
## before: 
<img width="768" alt="CleanShot 2023-07-29 at 18 54 49@2x" src="https://github.com/Code-Forge-Net/Remix-Dev-Tools/assets/4562878/15514996-f2cf-4e6b-9973-b2c87fda5c6d">

## after:
<img width="818" alt="CleanShot 2023-07-29 at 18 57 20@2x" src="https://github.com/Code-Forge-Net/Remix-Dev-Tools/assets/4562878/5f6bf646-6839-4ecc-812d-539455a06c84">
