### PR TITLE
fix/package-dts-error

### DIFF
--- a/src/RemixDevTools/RemixDevTools.tsx
+++ b/src/RemixDevTools/RemixDevTools.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { RDTContextProvider } from "./context/RDTContext";
-import { Tab } from "./tabs";
 import { useTimelineHandler } from "./hooks/useTimelineHandler";
 import { useDetachedWindowControls, usePersistOpen, useSettingsContext } from "./context/useRDTContext";
 import { useLocation } from "@remix-run/react";
@@ -58,6 +57,15 @@ function useHydrated() {
   }, []);
 
   return hydrated;
+}
+
+export interface Tab {
+  name: string;
+  icon: JSX.Element;
+  id: string;
+  component: JSX.Element;
+  requiresForge: boolean;
+  hideTimeline: boolean;
 }
 
 export interface RemixDevToolsProps {

--- a/src/RemixDevTools/layout/ContentPanel.tsx
+++ b/src/RemixDevTools/layout/ContentPanel.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { TimelineTab } from "../tabs/TimelineTab";
-import { Tab } from "../tabs";
+import { type Tab } from "../RemixDevTools";
 import { useRemixForgeSocket } from "../hooks/useRemixForgeSocket";
 import { useTabs } from "../hooks/useTabs";
 import { Fragment } from "react";

--- a/src/RemixDevTools/layout/Tabs.tsx
+++ b/src/RemixDevTools/layout/Tabs.tsx
@@ -3,7 +3,8 @@ import { CopySlash, Radio, X } from "lucide-react";
 import { useDetachedWindowControls, usePersistOpen, useSettingsContext } from "../context/useRDTContext";
 import { useRemixForgeSocket } from "../hooks/useRemixForgeSocket";
 import { useTabs } from "../hooks/useTabs";
-import { Tab, Tabs as TabType } from "../tabs";
+import { Tabs as TabType } from "../tabs";
+import { type Tab } from "../RemixDevTools";
 import { useHorizontalScroll } from "../hooks/useHorizontalScroll";
 import { twMerge } from "tailwind-merge";
 import {

--- a/src/RemixDevTools/tabs/index.tsx
+++ b/src/RemixDevTools/tabs/index.tsx
@@ -6,15 +6,6 @@ import { SettingsTab } from "./SettingsTab";
 
 export type Tabs = (typeof tabs)[number]["id"];
 
-export interface Tab {
-  name: string;
-  icon: JSX.Element;
-  id: string;
-  component: JSX.Element;
-  requiresForge: boolean;
-  hideTimeline: boolean;
-}
-
 const TAB_SIZE = 16;
 
 export const tabs = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { useRemixForgeSocket, initClient, initServer, RemixDevTools } from "./RemixDevTools";
-import { type Tab } from "./RemixDevTools/tabs";
+import { type Tab } from "./RemixDevTools/RemixDevTools";
 
 export type Plugin = (...args: any) => Tab;
 


### PR DESCRIPTION
# Description
When upgrading to `Remix-Dev-Tools` v2, I noticed a type error in the package. i was getting the error when running `tsc` on my repo which consumes `Remix-Dev-Tools`. This fixes it, but I'm not sure if you're cool with my solution.

<img width="1401" alt="Screenshot 2023-08-09 at 5 49 22 PM" src="https://github.com/Code-Forge-Net/Remix-Dev-Tools/assets/5226549/72788546-4ec1-4581-be0f-b00f3df7697d">


## Type of change: Bug fix
Move `Tab` type export to top level. This is a minor change that doesn't affect the current `dist` build folder structure or naming convention. 

# How Has This Been Tested?

I ran `npm run build` in remix-development-tools, the below `dist` error exists in `main` but not this branch.
```ts
dist/RemixDevTools/RemixDevTools.d.ts:1:21 - error TS2307: Cannot find module './tabs' or its corresponding type declarations.

1 import { Tab } from "./tabs";
                      ~~~~~~~~
```

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas; NOT APPLICABLE
- [ ] I have made corresponding changes to the documentation; NOT APPLICABLE
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works; NOT APPLICABLE
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules; NOT APPLICABLE
