### PR TITLE
Move getting started up in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,119 @@
 Remix Development Tools is an open-source package designed to enhance your development workflow when working with Remix, a full-stack JavaScript framework for building web applications. This package provides a user-friendly interface consisting of three tabs, **Active Page**, **Terminal**, **Settings**, **Errors** and **Routes**, along with a side tab called **Timeline**. With Remix Development Tools, you can efficiently monitor and manage various aspects of your Remix projects, including page information, URL parameters, server responses, loader data, routes, and more. You can
 also track down hydration issues with the **Errors** tab and view your routes in a tree/list view with the **Routes** tab.
 
+## Getting Started
+
+Make sure that everything is guarded by the NODE_ENV check so it doesn't break your production build if you installed it as a dev dependency!
+
+To install and utilize Remix Development Tools, follow these steps:
+
+1. Install the package via npm:
+
+```bash
+npm install remix-development-tools -D
+```
+
+2. Add the following to your application `root.tsx` file:
+
+```diff
+// Import styles
++ import rdtStylesheet from "remix-development-tools/index.css"; 
++ export const links: LinksFunction = () => [
+    // export the stylesheet in development only
++   ...(process.env.NODE_ENV === "development" ? [{ rel: "stylesheet", href: rdtStylesheet }] : []),
++ ] 
+ 
++ let AppExport = App;
+// This imports the dev tools only if you're in development
++ if(process.env.NODE_ENV === 'development') { 
++   const { withDevTools } = await import("remix-development-tools"); 
++   AppExport = withDevTools(AppExport);
++ }
+
++ export default AppExport;
+
+``` 
+If you're using CJS instead of ESM you can do the following instead:
+```diff
+ 
+if(process.env.NODE_ENV === 'development') { 
+- const { withDevTools } = await import("remix-development-tools"); 
++ const { withDevTools } = require("remix-development-tools"); 
+  AppExport = withDevTools
+}
+export default AppExport;
+
+``` 
+
+You're good to go! 
+
+If you want to add the server side logs and listeners you need to do one of the following:
+
+### Custom server setup
+
+Make sure that everything is guarded by the NODE_ENV check so it doesn't break your production build if you installed it as a dev dependency!
+
+If you're running a custom server this is what you need to do:
+1. Wrap your build in your server file with `withServerDevTools` function. This takes an optional second parameter that allows you to configure it.
+2. Wrap your re-imported build too if you are in manual mode.
+3. You're done! Here is the example code:
+
+```ts 
+  // Somewhere in your server.ts file
+  const build = await import(BUILD_PATH)
+  let devBuild = build
+  let devToolsConfig  = null;
+  // Make sure you guard this with NODE_ENV check
+  if(process.env.NODE_ENV === 'development') {
+    const { withServerDevTools, defineServerConfig } = await import("remix-development-tools/server"); 
+     // Allows you to define the configuration for the dev tools
+      devToolsConfig = defineServerConfig({ 
+      //... your config here ...
+    })
+    // wrap the build with the dev tools
+    devBuild = withServerDevTools(build, devToolsConfig)
+  }
+// Make sure you guard this with NODE_ENV check
+if(process.env.NODE_ENV === "development"){
+  // .... somewhere later in your code ...
+  // This makes sure the build is wrapped on reload, you will need this if you're running with the --manual flag
+  async function reloadBuild() {
+    devBuild = await import(`${BUILD_PATH}?update=${Date.now()}`)
+    // wrap the build with dev tools on re-import
+    devBuild = withServerDevTools(devBuild, devToolsConfig)
+    broadcastDevReady(devBuild)
+  }
+}
+```
+If you're using a CJS custom server you can replace the following lines:
+```diff
+- const { withServerDevTools, defineServerConfig } = await import("remix-development-tools/server"); 
++ const { withServerDevTools, defineServerConfig } = require("remix-development-tools/server"); 
+```
+
+### CJS remix server setup (remix run server started by remix dev)
+
+> [!NOTE]  
+> This is only needed when you're not running a custom server and you're using the remix dev server
+
+
+Just add the following command to your package.json:
+```diff
+- "dev": "remix dev",
++ "dev": "remix dev -c \"rdt-cjs-serve ./build/index.js\" --manual",
+```
+
+### ESM remix server setup (remix run server started by remix dev)
+
+> [!NOTE]  
+> This is only needed when you're not running a custom server and you're using the remix dev server
+
+Just add the following command to your package.json:
+```diff
+- "dev": "remix dev",
++ "dev": "remix dev -c \"rdt-serve ./build/index.js\" --manual",
+```
+
 ## How it looks
 ### Server logger
 ![server logger](./assets/logs.png) 
@@ -150,119 +263,6 @@ Detached mode allows you to un-dock the Remix Dev Tools from the browser and mov
 
 Embedded mode allows you to embed the Remix Dev Tools in your application. This is useful if you want to have the dev tools open in a particular
 page in your application only or you want to place it somewhere in the UI where it makes sense for your application.
-
-## Getting Started
-
-Make sure that everything is guarded by the NODE_ENV check so it doesn't break your production build if you installed it as a dev dependency!
-
-To install and utilize Remix Development Tools, follow these steps:
-
-1. Install the package via npm:
-
-```bash
-npm install remix-development-tools -D
-```
-
-2. Add the following to your application `root.tsx` file:
-
-```diff
-// Import styles
-+ import rdtStylesheet from "remix-development-tools/index.css"; 
-+ export const links: LinksFunction = () => [
-    // export the stylesheet in development only
-+   ...(process.env.NODE_ENV === "development" ? [{ rel: "stylesheet", href: rdtStylesheet }] : []),
-+ ] 
- 
-+ let AppExport = App;
-// This imports the dev tools only if you're in development
-+ if(process.env.NODE_ENV === 'development') { 
-+   const { withDevTools } = await import("remix-development-tools"); 
-+   AppExport = withDevTools(AppExport);
-+ }
-
-+ export default AppExport;
-
-``` 
-If you're using CJS instead of ESM you can do the following instead:
-```diff
- 
-if(process.env.NODE_ENV === 'development') { 
-- const { withDevTools } = await import("remix-development-tools"); 
-+ const { withDevTools } = require("remix-development-tools"); 
-  AppExport = withDevTools
-}
-export default AppExport;
-
-``` 
-
-You're good to go! 
-
-If you want to add the server side logs and listeners you need to do one of the following:
-
-### Custom server setup
-
-Make sure that everything is guarded by the NODE_ENV check so it doesn't break your production build if you installed it as a dev dependency!
-
-If you're running a custom server this is what you need to do:
-1. Wrap your build in your server file with `withServerDevTools` function. This takes an optional second parameter that allows you to configure it.
-2. Wrap your re-imported build too if you are in manual mode.
-3. You're done! Here is the example code:
-
-```ts 
-  // Somewhere in your server.ts file
-  const build = await import(BUILD_PATH)
-  let devBuild = build
-  let devToolsConfig  = null;
-  // Make sure you guard this with NODE_ENV check
-  if(process.env.NODE_ENV === 'development') {
-    const { withServerDevTools, defineServerConfig } = await import("remix-development-tools/server"); 
-     // Allows you to define the configuration for the dev tools
-      devToolsConfig = defineServerConfig({ 
-      //... your config here ...
-    })
-    // wrap the build with the dev tools
-    devBuild = withServerDevTools(build, devToolsConfig)
-  }
-// Make sure you guard this with NODE_ENV check
-if(process.env.NODE_ENV === "development"){
-  // .... somewhere later in your code ...
-  // This makes sure the build is wrapped on reload, you will need this if you're running with the --manual flag
-  async function reloadBuild() {
-    devBuild = await import(`${BUILD_PATH}?update=${Date.now()}`)
-    // wrap the build with dev tools on re-import
-    devBuild = withServerDevTools(devBuild, devToolsConfig)
-    broadcastDevReady(devBuild)
-  }
-}
-```
-If you're using a CJS custom server you can replace the following lines:
-```diff
-- const { withServerDevTools, defineServerConfig } = await import("remix-development-tools/server"); 
-+ const { withServerDevTools, defineServerConfig } = require("remix-development-tools/server"); 
-```
-
-### CJS remix server setup (remix run server started by remix dev)
-
-> [!NOTE]  
-> This is only needed when you're not running a custom server and you're using the remix dev server
-
-
-Just add the following command to your package.json:
-```diff
-- "dev": "remix dev",
-+ "dev": "remix dev -c \"rdt-cjs-serve ./build/index.js\" --manual",
-```
-
-### ESM remix server setup (remix run server started by remix dev)
-
-> [!NOTE]  
-> This is only needed when you're not running a custom server and you're using the remix dev server
-
-Just add the following command to your package.json:
-```diff
-- "dev": "remix dev",
-+ "dev": "remix dev -c \"rdt-serve ./build/index.js\" --manual",
-```
 
 ## Server dev tools configuration
 Here are the server config options:


### PR DESCRIPTION
Getting started gets a bit buried underneath the technical explanation. Personally I find it a little easier when a library/tool has the "Getting Started" section toward the top.

If you don't like it this way, that's totally fine, feel free to ignore