### PR TITLE
docs(installation): fix instructions for cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you're using CJS instead of ESM you can do the following instead:
 if(process.env.NODE_ENV === 'development') { 
 - const { withDevTools } = await import("remix-development-tools"); 
 + const { withDevTools } = require("remix-development-tools"); 
-  AppExport = withDevTools
+  AppExport = withDevTools(AppExport);
 }
 export default AppExport;
 


### PR DESCRIPTION
# Description

Without using `withDevTools(AppExport)`, Remix throws a warning:
```
Warning: Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render. Or maybe you meant to call this function rather than return it.
```

Fixes # (issue)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
It's just a change to the docs.

# Checklist:

- [ ] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
