### PR TITLE
Fixed usage of config settings by removing default initialState

### DIFF
--- a/src/client/context/RDTContext.tsx
+++ b/src/client/context/RDTContext.tsx
@@ -61,7 +61,6 @@ export const getSettings = () => {
   const settingsString = getStorageItem(REMIX_DEV_TOOLS_SETTINGS);
   const settings = tryParseJson<RemixDevToolsState["settings"]>(settingsString);
   return {
-    ...initialState.settings,
     ...settings,
   };
 };


### PR DESCRIPTION
# Description
Passing of config settings did not work because they were overwritten with the initial settings.

This fixes the passing of config settings when provided through the plugin:

```
import { vitePlugin as remix } from '@remix-run/dev';
import { defineConfig } from 'vite';
import { remixDevTools, defineRdtConfig } from 'remix-development-tools';

export default defineConfig({
	plugins: [
		remixDevTools(
			defineRdtConfig({
				client: {
					defaultOpen: false,
					panelLocation: 'top',
					position: 'top-right',
					hideUntilHover: true,
				},
			}),
		),
		remix(),
	],
});
```

Previously these settings were passed through (https://github.com/Code-Forge-Net/Remix-Dev-Tools/blob/main/src/client/context/RDTContext.tsx#L79), but overwritten by https://github.com/Code-Forge-Net/Remix-Dev-Tools/blob/main/src/client/context/RDTContext.tsx#L80 because the `settings` always included the default settings.


If this is a new feature please add a description of what was added and why below:

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

This has been tested locally, and can be tested with the above `vite.config.ts`.

- [ ] Unit tests

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
