### PR TITLE
Fixed weird headers in documentation site

### DIFF
--- a/docs/app/styles/documentation.css
+++ b/docs/app/styles/documentation.css
@@ -19,6 +19,12 @@
   & :is(:where(h3):has(code)) > code {
     @apply text-xl font-semibold !important;
   }
+
+  & :has(h3) {
+    & :is(h2:not(:has(+ h3))) {
+      @apply flex whitespace-pre-wrap text-2xl font-bold mb-4 text-[#10172A] dark:text-[#e2e8f0] !important;
+    }
+  }
 }
 
 #article-main:not(:has(h3)) {


### PR DESCRIPTION
# Description

Added a mini-correction to remove `h2` headers without `h3` looking weird

## Type of change

- [x] Documentation site change

# How Has This Been Tested?

Copying over my snippet from Remix PWA v4 site (not yet public)

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
