### PR TITLE
chore: changesets for v6.2.1

### DIFF
--- a/.changeset/ast-transform-aliased-imports.md
+++ b/.changeset/ast-transform-aliased-imports.md
@@ -1,0 +1,5 @@
+---
+"react-router-devtools": patch
+---
+
+Fix AST transform to correctly handle aliased imports (#251)

--- a/.changeset/bigint-depth-limit.md
+++ b/.changeset/bigint-depth-limit.md
@@ -1,0 +1,5 @@
+---
+"react-router-devtools": patch
+---
+
+Add depth limit and cycle detection to `convertBigIntToString` to prevent infinite recursion on circular or deeply nested objects (#250)


### PR DESCRIPTION
Adds changesets for the two bug-fix PRs merged into `main`, so the automated Release PR will cut **v6.2.1**.

## Changesets (both `patch`)
- **#250** `fix: add depth limit and cycle detection to convertBigIntToString` — prevents infinite recursion on circular/deeply nested objects
- **#251** `fix: ast transform for aliased imports` — correctly handles aliased imports

## Release flow
Once this merges to `main`, the `changesets/action` opens the **🚀 Release PR** which bumps `react-router-devtools` 6.2.0 → 6.2.1, updates the changelog, and on merge publishes to npm + creates the GitHub release/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)