### PR TITLE
ci: harden release with OIDC trusted publishing (TanStack-style, tokenless)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,42 +4,56 @@ on:
   push:
     branches:
       - main
+  # Manual safety valve: re-run publish for a version that was bumped but never
+  # published. Guarded below so a dispatch can only ever publish from main.
+  workflow_dispatch:
+
+concurrency:
+  # Never cancel an in-progress release; queue concurrent runs instead.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # push the version PR branch, create tags + GitHub releases
+  pull-requests: write # open/update the changesets "Release PR"
+  id-token: write # npm Trusted Publishing (OIDC) — no long-lived NPM_TOKEN needed
 
 jobs:
   release:
     name: Release
+    # Don't run on forks; only ever publish from main (incl. workflow_dispatch).
+    if: github.repository_owner == 'code-forge-io' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      actions: write
-      id-token: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          # Required so changesets/action can push the version PR branch. Only the
+          # ephemeral GITHUB_TOKEN is persisted (auto-expires at job end) — no PAT.
+          persist-credentials: true
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: "package.json"
+          # Pin to Node 24 (ships npm 11.x) so OIDC Trusted Publishing works even
+          # if pnpm delegates publishing to npm. npm OIDC needs >= 11.5.1.
+          node-version: "24"
 
       - name: Install Dependencies
         run: pnpm install
 
-      #      - name: 🔐 Setup npm auth
-      #        run: |
-      #          echo "registry=https://registry.npmjs.org" >> ~/.npmrc
-      #          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         env:
+          # Only used to open/update the Release PR and create GitHub releases.
+          # npm authentication is handled by OIDC Trusted Publishing (.npmrc
+          # provenance=true + id-token:write) — there is intentionally no NPM_TOKEN.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           title: "🚀 Release PR"
           commit: "chore: release"

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+provenance=true

--- a/packages/react-router-devtools/package.json
+++ b/packages/react-router-devtools/package.json
@@ -55,9 +55,7 @@
 			"default": "./dist/server.js"
 		}
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/forge-42/react-router-devtools.git"


### PR DESCRIPTION
Reworks the release flow to be **tokenless**, mirroring TanStack/ai. Supersedes the earlier PAT-based approach (the PAT added the exact secret-exposure risk we were trying to avoid, and the automated commit security review flagged it).

## Why the publish never happened for v6.2.1
The version bump (#257) landed on main but the package was never published to npm. The Release run that does `changeset publish` didn't fire after the Release PR merge (likely disrupted by the recent repo move). Rather than paper over it with a PAT, this adopts the more secure, proven TanStack pattern + a manual recovery valve.

## Changes
- **OIDC Trusted Publishing** — `.npmrc` `provenance=true` + `id-token: write`; **no `NPM_TOKEN`, no PAT**. pnpm 10.18 supports OIDC (pnpm#9812, closed 2025-07-30).
- **Pinned action SHAs** for checkout / pnpm / setup-node / changesets (supply-chain hardening).
- **Job guard** `github.repository_owner == 'code-forge-io' && github.ref == 'refs/heads/main'` — no fork runs, and `workflow_dispatch` can only publish from main.
- **Node pinned to 24** (npm 11) so OIDC works even if pnpm delegates to `npm publish`.
- **Dropped `actions: write`**; added non-cancelling `concurrency`.
- **`workflow_dispatch`** kept as a guarded manual recovery valve.
- Also: inlined `"files": ["dist"]` in package.json (biome was rejecting the multi-line form left by the version bump).

## Resolves security review findings
1. *Persisted PAT credentials* -> PAT removed; only the ephemeral `GITHUB_TOKEN` remains.
2. *Unrestricted workflow_dispatch* -> guarded to `main`.

## Required before this can publish (one-time, owner-only)
Configure a **trusted publisher** for `react-router-devtools` on npmjs.com:
npmjs.com -> package settings -> **Publishing access -> Trusted publisher -> GitHub Actions**
- Repository: `code-forge-io/react-router-devtools`
- Workflow filename: `publish.yaml`
- Environment: (leave blank)

**Order matters:** configure the trusted publisher *before* merging, otherwise the publish step will have no npm auth (NPM_TOKEN is gone).

## Publishing the stuck 6.2.1
After the trusted publisher is set up and this PR merges, the merge push triggers a Release run; with no changesets on main it goes straight to `changeset publish` and publishes 6.2.1 with provenance. (Or run `gh workflow run Release` manually.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
