### PR TITLE
fix: repository.url -> code-forge-io to unblock provenance publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/forge-42/react-router-devtools.git"
+		"url": "git+https://github.com/code-forge-io/react-router-devtools.git"
 	},
 	"bugs": {
-		"url": "https://github.com/forge-42/react-router-devtools/issues"
+		"url": "https://github.com/code-forge-io/react-router-devtools/issues"
 	},
 	"homepage": "https://react-router-devtools.forge42.dev/",
-	"readme": "https://github.com/forge-42/react-router-devtools#readme",
+	"readme": "https://github.com/code-forge-io/react-router-devtools#readme",
 	"scripts": {
 		"build": "nx affected --targets=build --exclude=test-apps/**,docs/**",
 		"build:all": "nx run-many --targets=build --exclude=test-apps/**,docs/**",

--- a/packages/react-router-devtools/package.json
+++ b/packages/react-router-devtools/package.json
@@ -58,13 +58,13 @@
 	"files": ["dist"],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/forge-42/react-router-devtools.git"
+		"url": "git+https://github.com/code-forge-io/react-router-devtools.git"
 	},
 	"bugs": {
-		"url": "https://github.com/forge-42/react-router-devtools/issues"
+		"url": "https://github.com/code-forge-io/react-router-devtools/issues"
 	},
 	"homepage": "https://react-router-devtools.forge42.dev/",
-	"readme": "https://github.com/forge-42/react-router-devtools#readme",
+	"readme": "https://github.com/code-forge-io/react-router-devtools#readme",
 	"scripts": {
 		"prepublishOnly": "npm run build",
 		"react-router-vite": "npm run dev -w test-apps/react-router-vite",


### PR DESCRIPTION
The v6.2.1 publish (via the new OIDC flow in #258) **signed provenance successfully** but npm rejected it with E422:

```
Failed to validate repository information: package.json: "repository.url" is
"git+https://github.com/forge-42/react-router-devtools.git", expected to match
"https://github.com/code-forge-io/react-router-devtools" from provenance
```

OIDC provenance is stamped with the repo's current location (`code-forge-io`), but the package manifest still pointed at the old `forge-42` org. npm requires them to match.

## Fix
Update `repository.url`, `bugs.url`, and `readme` from `forge-42` -> `code-forge-io` in both the published package and the root manifest. `homepage` (`forge42.dev` docs domain) is intentionally left unchanged — it's not a GitHub URL and isn't part of provenance validation.

## Result
6.2.1 is **not** on npm (the publish was cleanly rejected). Merging this triggers a Release run with no pending changesets -> `changeset publish` republishes 6.2.1, and provenance now validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)