### PR TITLE
Toggle include in prod values via environment variables

### DIFF
--- a/docs/content/03-configuration/03-general.mdx
+++ b/docs/content/03-configuration/03-general.mdx
@@ -87,6 +87,21 @@ export default defineConfig({
 });
 ```
 
+You can also control this behavior using environment variables.
+
+Again, you can selectively include different parts:
+
+- **`VITE_INCLUDE_CLIENT_IN_PROD=true`**: Include the devtools UI in production
+- **`VITE_INCLUDE_SERVER_IN_PROD=true`**: Include server-side logging and utilities in production
+- **`VITE_INCLUDE_DEVTOOLS_IN_PROD=true`**: Include TanStack DevTools integration in production
+
+**Example:**
+```sh
+# VITE_INCLUDE_CLIENT_IN_PROD=true
+VITE_INCLUDE_SERVER_IN_PROD=true # Include server logs in production
+VITE_INCLUDE_DEVTOOLS_IN_PROD=false
+```
+
 <WarningAlert title="Be careful!">
 If you decide to deploy parts to production you should be very careful that you don't expose the dev tools to your clients or anybody
 who is not supposed to see them.

--- a/packages/react-router-devtools/src/vite/plugin.tsx
+++ b/packages/react-router-devtools/src/vite/plugin.tsx
@@ -182,9 +182,9 @@ export const reactRouterDevTools: (args?: ReactRouterViteConfig) => Plugin[] = (
 		editorName: "Editor",
 	}
 
-	const includeClient = args?.includeInProd?.client ?? false
-	const includeServer = args?.includeInProd?.server ?? false
-	const includeDevtools = args?.includeInProd?.devTools ?? false
+	const includeClient = args?.includeInProd?.client ?? process.env.VITE_INCLUDE_CLIENT_IN_PROD === "true"
+	const includeServer = args?.includeInProd?.server ?? process.env.VITE_INCLUDE_SERVER_IN_PROD === "true"
+	const includeDevtools = args?.includeInProd?.devTools ?? process.env.VITE_INCLUDE_DEVTOOLS_IN_PROD === "true"
 	let port = 5173
 	// Get appDir synchronously from cache (will be populated when first route loads)
 	const appDir = cachedAppDir || "./app"


### PR DESCRIPTION
# Description

Adds the ability to include the plugin in production using environment variables as well.

Fixes #214 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Running builds both without and with the environment variables enabled in an example React Router project as well as a production React Router project.

- [ ] Unit tests

# Checklist:

- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
