### PR TITLE
fix: stop emitting the envFile deprecation warning on Vite 8

### DIFF
--- a/.changeset/vite8-envfile-deprecation.md
+++ b/.changeset/vite8-envfile-deprecation.md
@@ -1,0 +1,7 @@
+---
+"react-router-devtools": patch
+---
+
+Stop emitting the `envFile` deprecation warning on Vite 8.
+
+The internal vite-node server passes `envFile: false` to `createServer`, which Vite 8 deprecated in favour of `envDir: false`. Every Vite 8 consumer therefore saw `The 'envFile' option is deprecated, please use 'envDir: false' instead.` on startup, because the warning is emitted from a top-level `createServer` call that no user config can reach. The key is now chosen from the installed Vite major, so Vite 8 gets `envDir: false` while the existing `>=5` peers keep `envFile: false`.

--- a/packages/react-router-devtools/package.json
+++ b/packages/react-router-devtools/package.json
@@ -55,9 +55,7 @@
 			"default": "./dist/server.js"
 		}
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/code-forge-io/react-router-devtools.git"

--- a/packages/react-router-devtools/src/vite/node-server.ts
+++ b/packages/react-router-devtools/src/vite/node-server.ts
@@ -3,6 +3,8 @@ import { ViteNodeRunner } from "vite-node/client"
 import { ViteNodeServer } from "vite-node/server"
 import { installSourcemapsSupport } from "vite-node/source-map"
 
+const viteMajor = Number(viteVersion.split(".")[0])
+
 // create vite server
 const server = await createServer({
 	mode: "development",
@@ -17,11 +19,14 @@ const server = await createServer({
 		noDiscovery: true,
 	},
 	configFile: false,
-	envFile: false,
+	// Vite 8 deprecated `envFile` in favour of `envDir: false` and warns when
+	// it is passed. Older peers (>=5) only understand `envFile`, so pick the
+	// key the installed Vite expects.
+	...(viteMajor >= 8 ? ({ envDir: false } as const) : ({ envFile: false } as const)),
 	plugins: [],
 })
 // For old Vite, this is need to initialize the plugins.
-if (Number(viteVersion.split(".")[0]) < 6) {
+if (viteMajor < 6) {
 	await server.pluginContainer.buildStart({})
 }
 


### PR DESCRIPTION
## What

The vite-node server passes `envFile: false` to `createServer`. Vite 8 deprecated that option in favour of `envDir: false`, so every Vite 8 consumer sees this on startup:

```
The `envFile` option is deprecated, please use `envDir: false` instead.
```

The key is now picked from the installed Vite major: `envDir: false` on 8+, `envFile: false` below.

## Why

The warning is emitted from a top-level `createServer` call inside the plugin, so no consumer config can reach or suppress it — the fix has to be here.

Gated rather than renamed outright because the `vite` peer range is `>=5.0.0`. I verified `envDir: false` is honoured on 7 and 8, but not on 5/6; gating leaves those paths byte-for-byte unchanged.

## Also included: a red-CI fix

`packages/react-router-devtools/package.json` is reformatted (`"files": ["dist"]` back onto one line). The release bot rewrote it in becd7c9 and the Validation Pipeline did not run on that commit, so `biome ci .` has been failing on `main` ever since and every PR inherits the red check. Happy to split it out if you would rather land it separately.

## Verified

Same inline config both ways on Vite 8.1.3:

```
--- envFile: false (current) ---
The `envFile` option is deprecated, please use `envDir: false` instead.
   resolved envDir = false
--- envDir: false (patched) ---
   resolved envDir = false
```

Identical resolved config, no warning.

`biome ci .` is clean, `test:types` passes, `test:lib` passes.

Note that `test-apps/react-router-v8-vite` does not reproduce this: inside the workspace the package resolves its own `vite@7.2.2` devDependency rather than the app's Vite 8, so the warning only appears in a real consumer install.

Changeset included (patch).
