### PR TITLE
fix(ci): unbreak the release pipeline (unpublished versions + main going red)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://unpkg.com/@changesets/config@3.0.2/schema.json",
 	"changelog": "@changesets/cli/changelog",
-	"commit": true,
+	"commit": false,
 	"fixed": [],
 	"linked": [],
 	"access": "public",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
 		"check:fix": "biome check --fix .",
 		"changeset": "changeset",
 		"release": "changeset publish",
-		"local-release": "changeset version && changeset publish",
-		"version": "changeset version",
+		"local-release": "changeset version && biome format --write . && changeset publish",
+		"version": "changeset version && biome format --write .",
 		"test:unused": "knip",
 		"test:deps": "sherif -i react-router-devtools -i tailwindcss -p react-router-v8-vite",
 		"watch": "pnpm run build:all && nx watch --all -- pnpm run build:all"

--- a/packages/react-router-devtools/package.json
+++ b/packages/react-router-devtools/package.json
@@ -55,9 +55,7 @@
 			"default": "./dist/server.js"
 		}
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/code-forge-io/react-router-devtools.git"


### PR DESCRIPTION
Two independent bugs in the release pipeline, both traced from "6.2.2 never got published".

## Bug 1 — the version commit suppresses its own publish

`.changeset/config.json` had `"commit": true`. Changesets normalizes that to `["@changesets/cli/commit", { skipCI: "version" }]`, so `changeset version` (run via `pnpm run version`) creates the version commit *itself*, appending GitHub's skip-ci directive to the message:

```
RELEASING: Releasing 1 package(s)

Releases:
  react-router-devtools@6.2.2

<skip-ci directive>
```

Two consequences:

1. The `commit: "chore: release"` message configured in `.github/workflows/publish.yaml` was never used — the action had nothing left to commit.
2. The directive survived the merge of the Release PR onto `main`, so GitHub skipped **every** workflow on that push. The Release workflow — the only thing that runs `changeset publish` — never fired.

### Evidence

`6.2.2` was bumped by #263 (merged Jun 19, `becd7c9`) and never reached npm:

```
$ gh api ".../actions/runs?head_sha=becd7c954d7aba358418fa5aee6e253344cce01e"
total_count: 0
```

Zero workflow runs against the version commit. No tag, no GitHub release, npm `latest` stuck on `6.2.1` for five weeks.

The bug is not new — it was only ever masked. `6.2.1`'s version commit (`a46c47f`) hit the same wall; what shipped it was the *next, unrelated* push to `main` (`6eab97d`), which found no pending changesets and fell through to the publish branch. Compare timestamps: that run started 11:17, npm recorded `6.2.1` at 11:18. Every release so far has published by accident, riding whatever push happened to land next. `6.2.2` had no such ride.

This PR's first commit initially reproduced the bug on itself — it quoted the directive literally, and GitHub skipped CI on this branch too (0 runs). Reworded; CI then ran. That is about as direct a confirmation as the diagnosis could get.

### Fix

`"commit": false` — leave the commit to `changesets/action`, which uses the workflow's `chore: release` message with no skip directive. Merging a Release PR then triggers Release and publishes.

## Bug 2 — every release turns `main` red

`changeset version` also rewrites `packages/react-router-devtools/package.json` with its own JSON printer, expanding `"files": ["dist"]` onto three lines. Biome wants it collapsed, so each release commit lands a formatting violation on `main` — and Biome lint then fails on that commit and on every PR opened afterwards until someone collapses it by hand.

Ping-ponging for three releases straight:

| commit | effect |
|---|---|
| `a46c47f` `RELEASING: ...` | expands (release breaks it) |
| `0263127` `ci: harden release` | collapses (hand fix) |
| `becd7c9` `RELEASING: ...` | expands (release breaks it again) |

`main` is in the expanded state right now, which is why the Validation Pipeline went red on the Vite 8 PR 3 days ago.

### Fix

Chain `biome format --write .` after `changeset version` in the `version` and `local-release` scripts, so the version commit is formatted when created. The `files` collapse in this PR repairs `main`'s current state.

## Verification

Ran a scratch changeset through `pnpm run version` locally with deps installed (repo-pinned Biome 1.9.4, not a global one):

- `changeset version` expands the array → formatter collapses it back (`Fixed 1 file`) → `biome check .` passes across all 224 files
- changesets reports `"Review them and commit at your leisure"` instead of creating its own commit, confirming `"commit": false` takes effect

Scratch changeset and bump artifacts reverted; the diff is 2 files, 3 insertions, 5 deletions.

## 6.2.2 has been unblocked separately

Published via the `workflow_dispatch` safety valve added in #258 (run [30378689522](https://github.com/code-forge-io/react-router-devtools/actions/runs/30378689522)):

- npm `latest` → `6.2.2`, with SLSA provenance (`https://slsa.dev/provenance/v1`)
- tag `react-router-devtools@6.2.2` + GitHub release created

So this PR is purely the forward fix; no republish needed.

## What to watch after merge

The next release should show a `chore: release` commit on `main` with a Release workflow run attached to it, publishing to npm with no manual dispatch, and leaving `main` formatted. No changeset included here — CI config only, no published package changed.
